### PR TITLE
fix bug when only im_id is provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.visenze</groupId>
     <artifactId>visearch-java-sdk</artifactId>
     <name>ViSearch Java SDK</name>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>jar</packaging>
     <url>https://github.com/visenze/visearch-sdk-java</url>
     <description>ViSearch Java SDK</description>

--- a/src/main/java/com/visenze/visearch/internal/SearchOperationsImpl.java
+++ b/src/main/java/com/visenze/visearch/internal/SearchOperationsImpl.java
@@ -80,7 +80,12 @@ public class SearchOperationsImpl extends BaseViSearchOperations implements Sear
         InputStream imageStream = uploadSearchParams.getImageStream();
         String imageUrl = uploadSearchParams.getImageUrl();
         ViSearchHttpResponse response;
-        if (imageFile == null && imageStream == null && (Strings.isNullOrEmpty(imageUrl))) {
+
+        // if im_id is available no need to check for image
+        if (!Strings.isNullOrEmpty(uploadSearchParams.getImId())){
+            response = viSearchHttpClient.post(ENDPOINT_UPLOAD_SEARCH, uploadSearchParams.toMap());
+        }
+        else if (imageFile == null && imageStream == null && (Strings.isNullOrEmpty(imageUrl))) {
             throw new InternalViSearchException(ResponseMessages.INVALID_IMAGE_SOURCE);
             // throw new IllegalArgumentException("Must provide either an image File, InputStream of the image, or a valid image url to perform upload search");
         } else if (imageFile != null) {

--- a/src/test/java/com/visenze/visearch/ViSearchSearchOperationsTest.java
+++ b/src/test/java/com/visenze/visearch/ViSearchSearchOperationsTest.java
@@ -420,4 +420,21 @@ public class ViSearchSearchOperationsTest {
         UploadSearchParams uploadSearchParams = new UploadSearchParams(inputStream);
         searchOperations.uploadSearch(uploadSearchParams);
     }
+
+    // should not throw anything
+    @Test
+    public void testUploadSearchParamsImId() {
+        String responseBody = "{\"status\":\"OK\",\"method\":\"search\",\"error\":[],\"page\":1,\"limit\":10,\"total\":20,\"result\":[{\"im_name\":\"test_im_0\"},{\"im_name\":\"test_im_1\"},{\"im_name\":\"test_im_2\"},{\"im_name\":\"test_im_3\"},{\"im_name\":\"test_im_4\"},{\"im_name\":\"test_im_5\"},{\"im_name\":\"test_im_6\"},{\"im_name\":\"test_im_7\"},{\"im_name\":\"test_im_8\"},{\"im_name\":\"test_im_9\"}]}";
+        ViSearchHttpResponse response = mock(ViSearchHttpResponse.class);
+        when(response.getBody()).thenReturn(responseBody);
+        when(mockClient.post(anyString(), Matchers.<Multimap<String, String>>any())).thenReturn(response);
+
+        SearchOperations searchOperations = new SearchOperationsImpl(mockClient, objectMapper);
+        UploadSearchParams uploadSearchParams = new UploadSearchParams();
+        uploadSearchParams.setImId("abc");
+        PagedSearchResult sr = searchOperations.uploadSearch(uploadSearchParams);
+
+        assertEquals(null, sr.getErrorMessage());
+
+    }
 }


### PR DESCRIPTION
If im_id is provided, it should take priority and override any im_url, image parameter. There should be no error given when passing the upload params to search.

@houdejun214 , pls help to review. Thank you.