### PR TITLE
[API-5401] Fix incorrect endpoint for recommendations

### DIFF
--- a/src/main/java/com/visenze/visearch/internal/SearchOperationsImpl.java
+++ b/src/main/java/com/visenze/visearch/internal/SearchOperationsImpl.java
@@ -24,7 +24,7 @@ public class SearchOperationsImpl extends BaseViSearchOperations implements Sear
     private static final String ENDPOINT_DISCOVER_SEARCH = "/discoversearch";
     private static final String ENDPOINT_UPLOAD_SEARCH = "/uploadsearch";
     private static final String ENDPOINT_SEARCH = "/search";
-    private static final String ENDPOINT_RECOMMENDATION = "/recommendation";
+    private static final String ENDPOINT_RECOMMENDATION = "/recommendations";
     private static final String ENDPOINT_COLOR_SEARCH = "/colorsearch";
     private static final String ENDPOINT_SIMILAR_PRODUCTS_SEARCH = "/similarproducts";
     private static final String ENDPOINT_EXTRACT_FEATURE= "/extractfeature";

--- a/src/test/java/com/visenze/visearch/ViSearchSearchOperationsTest.java
+++ b/src/test/java/com/visenze/visearch/ViSearchSearchOperationsTest.java
@@ -1254,7 +1254,7 @@ public class ViSearchSearchOperationsTest {
         Multimap<String, String> expectedParams = HashMultimap.create();
         expectedParams.put("im_name", "im_name");
         expectedParams.put("score", "false");
-        given(mockClient.get(eq("/recommendation"), eq(expectedParams))).willReturn(response);
+        given(mockClient.get(eq("/recommendations"), eq(expectedParams))).willReturn(response);
 
         SearchOperations searchOperations = new SearchOperationsImpl(mockClient, objectMapper);
         RecommendSearchParams searchParams = new RecommendSearchParams("im_name");


### PR DESCRIPTION
Issue found during the integration test: the correct recommendation API endpoint should be `/recommendations`, and sorry for this mistake.